### PR TITLE
Simplify subagent depth handling

### DIFF
--- a/codex-rs/tui/src/prompt_for_review_branch_batch_command.md
+++ b/codex-rs/tui/src/prompt_for_review_branch_batch_command.md
@@ -7,6 +7,7 @@ Files:
 {file_list}
 
 Instructions:
+
 - For any file you inspect, fetch minimal hunks only: `git diff --no-color -U0 {base}...HEAD -- -- <path>`.
 - Scope findings ONLY to code overlapping the branch diff.
 - Follow the existing review schema from the system prompt; output ONLY the JSON object.
@@ -14,21 +15,25 @@ Instructions:
 - If two candidate issues are effectively the same, prefer the higher-confidence one.
 
 Static checks for this batch (run, don’t auto‑fix):
-- You MUST attempt to discover and run configured project linters/type checkers for the files in this batch. Begin by briefly listing which checks you will run (or why none are applicable), then run them.
+
+- Do NOT run build, serve, or long‑running dev commands. Only use lightweight linters/type‑checkers.
+- Prefer running direct tool CLIs; avoid package scripts that may invoke builds.
 - Identify affected subprojects from the files in this batch and run the project’s checker/linter only for those parts.
-  - Rust: `cargo clippy -p <crate> --tests --all-features` (no `--fix`) and/or `cargo check -p <crate>`.
-  - JS/TS: `npm run -w <pkg> lint` and `npm run -w <pkg> typecheck`.
+  - Rust: `cargo clippy -p <crate> --tests --all-features` (no `--fix`) and/or `cargo check -p <crate>` if available.
+  - JS/TS: `eslint` and `tsc --noEmit` if available; do not run `npm run build`, `vite dev`, `next dev`, etc.
   - Python: `ruff`/`flake8` and `mypy` for the batch’s modules.
 - Record any errors/warnings overlapping this batch; convert substantive ones into findings (cite rule/lint), otherwise summarize under `overall_explanation`.
-- If a checker cannot run, state exactly what you tried and why it could not run, then proceed.
+- If a checker is unavailable or cannot run, state exactly what you tried and why, then proceed.
 
 Skip low-value files unless there is a direct, non-speculative impact — and do not fetch diffs for them:
+
 - Lockfiles (e.g., `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Cargo.lock`).
 - Generated/vendored or minified assets; images and other binaries.
 - Doc-only changes that do not affect correctness/security.
-If such files appear in the batch list, omit them and continue; only fetch a minimal hunk for them if you have a concrete, high-confidence reason that they affect correctness/security.
+  If such files appear in the batch list, omit them and continue; only fetch a minimal hunk for them if you have a concrete, high-confidence reason that they affect correctness/security.
 
 Context exploration (allowed, but keep it tight):
+
 - If a finding depends on behavior in a related file not listed above (e.g., a called function or config include), you MAY fetch a minimal hunk for that related file to confirm the conclusion.
 - Prefer targeted commands (e.g., `git diff -U0 {base}...HEAD -- -- related/path`, `git show {base}:related/path` for a few lines) over broad scans.
 - Do not expand scope beyond what is necessary to verify the specific finding.

--- a/codex-rs/tui/src/prompt_for_review_branch_command.md
+++ b/codex-rs/tui/src/prompt_for_review_branch_command.md
@@ -5,31 +5,37 @@ Diff range: {base}...HEAD.
 Scope findings ONLY to code overlapping the branch diff. Follow the existing review schema and constraints. If the branch is large, prioritize highest‑risk areas first and summarize what remains in the overall_explanation.
 
 Procedure:
+
 - Enumerate changed files: `git diff --name-only --diff-filter=ACDMRTUXB --no-color {base}...HEAD`.
 - For any file you inspect, fetch minimal hunks: `git diff --no-color -U0 {base}...HEAD -- -- <path>`.
 - Prioritize in this order: security‑sensitive I/O/auth/crypto; public APIs and error handling; core logic; migrations/scripts/build logic.
 - If you cannot cover everything in one pass, review in batches and present the highest‑impact findings first.
 
 Static checks (run, don’t auto‑fix):
-- You MUST attempt to discover and run configured project linters/type checkers for the files in scope. Begin by briefly listing which checks you will run (or why none are applicable), then run them.
+
+- Do NOT run build, serve, or long‑running dev commands. Only use lightweight linters/type‑checkers.
+- Prefer running direct tool CLIs; avoid package scripts that may invoke builds.
 - Determine affected subprojects from the changed paths and run the project’s checker/linter only for those parts.
-  - Rust: run `cargo clippy -p <crate> --tests --all-features` (no `--fix`) and/or `cargo check -p <crate>` for each affected crate.
-  - JS/TS: run `npm run -w <pkg> lint` and `npm run -w <pkg> typecheck` where applicable.
-  - Python: run `ruff`/`flake8` and `mypy` scoped to changed modules.
+  - Rust: `cargo clippy -p <crate> --tests --all-features` (no `--fix`) and/or `cargo check -p <crate>` if available.
+  - JS/TS: `eslint` and `tsc --noEmit` if available; do not run `npm run build`, `vite dev`, `next dev`, etc.
+  - Python: `ruff`/`flake8` and `mypy` scoped to changed modules.
 - Record any errors or warnings that overlap the diff. Elevate substantive ones to findings (cite the rule/lint), otherwise summarize them under `overall_explanation` as “Checker/Linter notes”.
-- If a checker cannot run, state exactly what you tried and why it could not run, then continue with manual review.
+- If a checker is unavailable or cannot run, state exactly what you tried and why, then continue with manual review.
 
 Scope filters (skip "junk" files unless there is a direct, non‑speculative impact — and avoid fetching diffs for them):
+
 - Package manager lockfiles (e.g., `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Cargo.lock`).
 - Generated code, vendored bundles, and minified assets.
 - Large binary assets (images, fonts, media) and formatting‑only changes.
 - Pure docs/changelogs unless they create a correctness or security risk.
-If such files are present, omit them; only fetch a minimal hunk if you have a specific, high‑confidence reason they affect correctness/security.
+  If such files are present, omit them; only fetch a minimal hunk if you have a specific, high‑confidence reason they affect correctness/security.
 
 Context exploration (allowed when needed):
+
 - If assessing a change requires peeking at a related file (dependency, included config, or caller/callee), you MAY fetch a minimal hunk or a small slice from base vs HEAD to verify the conclusion.
 - Keep it narrowly targeted (specific functions/lines) and avoid broad scans; only include enough context to confirm or fix the issue.
 
 Constraints:
+
 - Do not paste full diffs; cite exact `file:line` ranges.
 - Keep comments brief and concrete; follow the JSON schema from the system prompt (no extra prose).


### PR DESCRIPTION
## Summary
- treat  as a nesting guard instead of a sibling counter so the root session can open multiple helpers concurrently while still blocking nested children
- remove the atomic depth bookkeeping now that subagent tools stay disabled for children; update the Session tests to assert the new concurrency semantics
- let the TUI send messages immediately when a subagent tab is focused and clarify the review prompts about running available checkers

## Testing
- cargo test -p codex-core
- cargo test -p codex-tui
